### PR TITLE
Integer division results in no adaptation

### DIFF
--- a/ptemcee/ensemble.py
+++ b/ptemcee/ensemble.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import attr
 import numpy as np
 import itertools


### PR DESCRIPTION
When decay and kappa are calculated in `_get_ladder_adjustment` in (lines 180 and 181 in `ensemble.py`), a division with integers is performed. Since `decay` is always less than 1, this results in decay and kappa always being zero if you're not using python 3. The result is the betas are never changed.

This fixes that by importing division from future in `ensemble.py`.