### PR TITLE
BUG: Sampler should accept betas as an int

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 cache: pip
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
+    - "3.8
 install:
     - make init
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
-    - "3.8
+    - "3.8"
 install:
     - make init
 script:

--- a/ptemcee/sampler.py
+++ b/ptemcee/sampler.py
@@ -5,6 +5,7 @@ from __future__ import (division, print_function, absolute_import,
 
 __all__ = ['make_ladder', 'Sampler']
 
+import operator
 import attr
 import itertools
 import numpy as np
@@ -185,6 +186,13 @@ class Sampler(object):
 
     @betas.validator
     def _validate_betas(self, attribute, value):
+        try:
+            # see if betas is an integer.
+            operator.index(value)
+            return
+        except TypeError:
+            pass
+
         if len(value) < 1:
             raise ValueError('Need at least one temperature!')
         if (value < 0).any():

--- a/ptemcee/sampler.py
+++ b/ptemcee/sampler.py
@@ -188,7 +188,9 @@ class Sampler(object):
     def _validate_betas(self, attribute, value):
         try:
             # see if betas is an integer.
-            operator.index(value)
+            v = operator.index(value)
+            if v < 1:
+                raise ValueError("Need at least one temperature")
             return
         except TypeError:
             pass

--- a/ptemcee/tests.py
+++ b/ptemcee/tests.py
@@ -307,6 +307,13 @@ class Tests(object):
                           betas=make_ladder(self.ndim, self.ntemps, Tmax=self.Tmax))
         self.check_sampler(sampler, p0=self.p0)
 
+    def test_betas(self):
+        sampler = Sampler(self.nwalkers, self.ndim,
+                          LogLikeGaussian(self.icov),
+                          LogPriorGaussian(self.icov, cutoff=self.cutoff),
+                          betas=20)
+        assert sampler.betas.shape[0] == 20
+
     def test_gaussian_adapt(self):
         sampler = Sampler(self.nwalkers, self.ndim,
                           LogLikeGaussian(self.icov),


### PR DESCRIPTION
The rewritten Sampler should accept an `int` for the `betas` parameter. Indeed, `Sampler.__attrs_post_init__` indicates that it's allowed. So change the betas validator to allow ints.

Whilst we're at it update the travis script to dump old python versions.